### PR TITLE
Add attestation annotators and link annotations to device id

### DIFF
--- a/internal/annotators/attestation.go
+++ b/internal/annotators/attestation.go
@@ -1,0 +1,46 @@
+package annotators
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/KarimElghamry/alvarium-sdk-go/pkg/config"
+	"github.com/KarimElghamry/alvarium-sdk-go/pkg/contracts"
+	"github.com/KarimElghamry/alvarium-sdk-go/pkg/interfaces"
+)
+
+type AttestationAnnotator struct {
+	hash contracts.HashType
+	kind contracts.AnnotationType
+	sign config.SignatureInfo
+}
+
+func NewAttestationAnnotator(cfg config.SdkInfo) interfaces.Annotator {
+	a := AttestationAnnotator{}
+	a.hash = cfg.Hash.Type
+	a.kind = contracts.AnnotationSource
+	a.sign = cfg.Signature
+	return &a
+}
+
+func (a *AttestationAnnotator) Do(ctx context.Context, data []byte) (contracts.Annotation, error) {
+	deviceId, ok := ctx.Value("deviceId").([]byte)
+	if !ok {
+		return contracts.Annotation{}, errors.New("`deviceId` not found in attestation annotator's context")
+	}
+
+	key := DeriveHash(a.hash, deviceId)
+
+	hostname, _ := os.Hostname()
+
+	annotation := contracts.NewAnnotation(key, a.hash, hostname, a.kind, true)
+	sig, err := SignAnnotation(a.sign.PrivateKey, annotation)
+
+	if err != nil {
+		return contracts.Annotation{}, err
+	}
+
+	annotation.Signature = string(sig)
+	return annotation, nil
+}

--- a/internal/annotators/attestation_test.go
+++ b/internal/annotators/attestation_test.go
@@ -1,0 +1,47 @@
+package annotators
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/KarimElghamry/alvarium-sdk-go/pkg/config"
+)
+
+func TestAttestationAnnotation(t *testing.T) {
+	b, err := ioutil.ReadFile("../../test/res/config.json")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	var cfg config.SdkInfo
+	err = json.Unmarshal(b, &cfg)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	tests := []struct {
+		name        string
+		data        string
+		cfg         config.SdkInfo
+		expectError bool
+	}{
+		{"check is satisfied", "foo", cfg, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attest := NewAttestationAnnotator(cfg)
+			a, err := attest.Do(context.Background(), []byte(tt.data))
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+			if !a.IsSatisfied {
+				t.Error("Attestation Annotation's isSatisfied is not true")
+			}
+			if true { // TODO:(Ali Amin) test correct device id ?
+				t.Error("Invalid device id")
+			}
+		})
+	}
+}

--- a/internal/annotators/attestation_test.go
+++ b/internal/annotators/attestation_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/KarimElghamry/alvarium-sdk-go/pkg/config"
+	"github.com/KarimElghamry/alvarium-sdk-go/pkg/contracts"
 )
 
 func TestAttestationAnnotation(t *testing.T) {
@@ -32,14 +33,14 @@ func TestAttestationAnnotation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			attest := NewAttestationAnnotator(cfg)
-			a, err := attest.Do(context.Background(), []byte(tt.data))
+			a, err := attest.Do(context.WithValue(context.Background(), contracts.DeviceIdKey, "foo"), []byte(tt.data))
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
 			if !a.IsSatisfied {
 				t.Error("Attestation Annotation's isSatisfied is not true")
 			}
-			if true { // TODO:(Ali Amin) test correct device id ?
+			if a.DeviceId != "foo" {
 				t.Error("Invalid device id")
 			}
 		})

--- a/internal/annotators/pki.go
+++ b/internal/annotators/pki.go
@@ -61,6 +61,12 @@ func (a *PkiAnnotator) Do(ctx context.Context, data []byte) (contracts.Annotatio
 	if err != nil {
 		return contracts.Annotation{}, err
 	}
+
+	deviceId, ok := ctx.Value(contracts.DeviceIdKey).(string)
+	if ok {
+		annotation.DeviceId = deviceId
+	}
+
 	annotation.Signature = string(signed)
 	return annotation, nil
 }

--- a/internal/annotators/remote_tpm_test.go
+++ b/internal/annotators/remote_tpm_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/KarimElghamry/alvarium-sdk-go/pkg/config"
+	"github.com/KarimElghamry/alvarium-sdk-go/pkg/contracts"
 	"github.com/KarimElghamry/alvarium-sdk-go/test"
 )
 
@@ -51,7 +52,7 @@ func TestRemoteTpmAnnotator_DO(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			remoteTpm := NewRemoteTpmAnnotator(tt.cfg)
-			annotation, err := remoteTpm.Do(context.Background(), tt.data)
+			annotation, err := remoteTpm.Do(context.WithValue(context.Background(), contracts.DeviceIdKey, "foo"), tt.data)
 			test.CheckError(err, tt.expectedError, tt.name, t)
 			if annotation.IsSatisfied != tt.isSatisfied {
 				t.Errorf("output annotation isSatisfied is: %t. expected value is: %t", annotation.IsSatisfied, tt.isSatisfied)

--- a/internal/annotators/tls.go
+++ b/internal/annotators/tls.go
@@ -54,6 +54,12 @@ func (a *TlsAnnotator) Do(ctx context.Context, data []byte) (contracts.Annotatio
 	if err != nil {
 		return contracts.Annotation{}, err
 	}
+
+	deviceId, ok := ctx.Value(contracts.DeviceIdKey).(string)
+	if ok {
+		annotation.DeviceId = deviceId
+	}
+
 	annotation.Signature = string(sig)
 	return annotation, nil
 }

--- a/internal/annotators/tpm.go
+++ b/internal/annotators/tpm.go
@@ -61,6 +61,11 @@ func (a *TpmAnnotator) Do(ctx context.Context, data []byte) (contracts.Annotatio
 	if err != nil {
 		return contracts.Annotation{}, err
 	}
+
+	deviceId, ok := ctx.Value(contracts.DeviceIdKey).(string)
+	if ok {
+		annotation.DeviceId = deviceId
+	}
 	annotation.Signature = string(sig)
 	return annotation, nil
 }

--- a/pkg/contracts/annotation.go
+++ b/pkg/contracts/annotation.go
@@ -16,14 +16,16 @@ package contracts
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/oklog/ulid/v2"
 	"time"
+
+	"github.com/oklog/ulid/v2"
 )
 
 // Annotation represents an individual criterion of evaluation in regard to a piece of data
 type Annotation struct {
 	Id          ulid.ULID      `json:"id,omitempty"`        // Id should probably be a ULID -- uniquely identifies the annotation itself
 	Key         string         `json:"key,omitempty"`       // Key is the hash value of the data being annotated
+	DeviceId    string         `json:"deviceId,omitempty"`  // DeviceId is the device identifier that the sdk is publishing annotations from
 	Hash        HashType       `json:"hash,omitempty"`      // Hash identifies which algorithm was used to construct the hash
 	Host        string         `json:"host,omitempty"`      // Host is the hostname of the node making the annotation
 	Kind        AnnotationType `json:"kind,omitempty"`      // Kind indicates what kind of annotation this is
@@ -54,6 +56,7 @@ func (a *Annotation) UnmarshalJSON(data []byte) (err error) {
 	type Alias struct {
 		Id          ulid.ULID
 		Key         string
+		Deviceid    string
 		Hash        HashType
 		Host        string
 		Kind        AnnotationType
@@ -76,6 +79,7 @@ func (a *Annotation) UnmarshalJSON(data []byte) (err error) {
 	}
 
 	a.Id = x.Id
+	a.DeviceId = x.Deviceid
 	a.Key = x.Key
 	a.Hash = x.Hash
 	a.Host = x.Host

--- a/pkg/contracts/constants.go
+++ b/pkg/contracts/constants.go
@@ -66,12 +66,13 @@ func (t StreamType) Validate() bool {
 type AnnotationType string
 
 const (
-	AnnotationPKI       AnnotationType = "pki"
-	AnnotationPKIHttp   AnnotationType = "pki-http"
-	AnnotationSource    AnnotationType = "src"
-	AnnotationTLS       AnnotationType = "tls"
-	AnnotationTPM       AnnotationType = "tpm"
-	AnnotationRemoteTPM AnnotationType = "remote-tpm"
+	AnnotationPKI         AnnotationType = "pki"
+	AnnotationPKIHttp     AnnotationType = "pki-http"
+	AnnotationSource      AnnotationType = "src"
+	AnnotationTLS         AnnotationType = "tls"
+	AnnotationTPM         AnnotationType = "tpm"
+	AnnotationRemoteTPM   AnnotationType = "remote-tpm"
+	AnnotationAttestation AnnotationType = "attest"
 )
 
 func (t AnnotationType) Validate() bool {

--- a/pkg/contracts/constants.go
+++ b/pkg/contracts/constants.go
@@ -107,3 +107,9 @@ func (d DerivedComponent) Validate() bool {
 	}
 	return false
 }
+
+type ContextKey string
+
+const (
+	DeviceIdKey ContextKey = "deviceId"
+)


### PR DESCRIPTION
* Add attestation annotators and annotations with relevant unit tests and constants
* Added a `DeviceIdKey` constant that is used in the annotator's `Do` context bag to avoid using string literals that can cause collisions
* Make the `deviceId` obligatory in device annotators and optional in generic data annotators 